### PR TITLE
Refines admin/editor checks and enhances editor features

### DIFF
--- a/app/Http/Controllers/api/UserController.php
+++ b/app/Http/Controllers/api/UserController.php
@@ -150,6 +150,15 @@ class UserController extends Controller
 
         return response()->json(['message' => 'User role updated successfully', 'user' => $user]);
     }
+   
+    public function getEditors(Request $request)
+    {
+        
+        $this->checkAdmin($request);
 
+        $editors = User::where('role', 'editor')->get(['id', 'name', 'email', 'role']);
+
+        return response()->json($editors);
+    }
 
 }

--- a/database/migrations/2025_03_26_143252_create_pages_table.php
+++ b/database/migrations/2025_03_26_143252_create_pages_table.php
@@ -14,10 +14,11 @@ return new class extends Migration
         Schema::create('pages', function (Blueprint $table) {
             $table->id();
             $table->foreignId('conference_id')->constrained('conferences')->onDelete('cascade');
-            $table->string('title')->unique(); 
+            $table->string('title');
             $table->text('content');
             $table->foreignId('created_by')->constrained('users');
             $table->timestamps();
+            $table->unique(['conference_id', 'title']);
         });
     }
 

--- a/database/seeders/EditorSeeder.php
+++ b/database/seeders/EditorSeeder.php
@@ -15,7 +15,7 @@ class EditorSeeder extends Seeder
      */
     public function run(): void
     {
-        $superAdmin = User::where('role', 'admin')->first();
+        $admin = User::where('role', 'admin')->first();
         $editor = User::where('role', 'editor')->first();
         $conferences = Conference::all();
 
@@ -23,7 +23,7 @@ class EditorSeeder extends Seeder
             Editor::create([
                 'user_id' => $editor->id,
                 'conference_id' => $conference->id,
-                'assigned_by' => $superAdmin->id,
+                'assigned_by' => $admin->id,
             ]);
         }
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,6 +17,10 @@ Route::middleware('auth:sanctum')->group(function (){
     Route::post('/logout', [AuthController::class,'logout']);
     Route::delete('/user/delete', [UserController::class, 'deleteOwnAccount']);
     Route::patch('/user/password', [UserController::class, 'changePassword']);
+
+    
+    Route::get('/editors/check/{conference_id}', [EditorController::class, 'checkEditorStatus']);
+    Route::get('/users/editors', [UserController::class, 'getEditors'])->name('users.editors');
 });
 
 //Reset password routes
@@ -36,6 +40,8 @@ Route::middleware('auth:sanctum')->prefix('super-admin')->group(function () {
     Route::delete('/users/{id}', [SuperAdminController::class, 'destroy']);
     Route::patch('/users/{id}/assign-role', [SuperAdminController::class, 'assignRole']);
 });
+
+
 
 Route::get('/conferences', [ConferenceController::class, 'getAllConferences']);
 Route::get('/conferences/{id}', [ConferenceController::class, 'getConference']);


### PR DESCRIPTION
Streamlines admin role verification by limiting checks to 'admin' only. Improves editor retrieval logic for conferences and adds editor status check functionality. Updates permission handling in PageController to validate conference-specific editor access. Enhances database schema for unique conference-page titles and adjusts seeder logic. Introduces new API routes for editor-related actions.