### PR TITLE
Updates role validation and enforces cascading deletes

### DIFF
--- a/app/Http/Controllers/api/SuperAdminController.php
+++ b/app/Http/Controllers/api/SuperAdminController.php
@@ -37,7 +37,7 @@ class SuperAdminController extends Controller
         $request->validate([
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:users,email',
-            'role' => 'required|in:admin,super_admin',
+            'role' => 'required|in:admin,editor',
         ]);
 
         $user = User::create([
@@ -77,7 +77,7 @@ class SuperAdminController extends Controller
             'name' => 'sometimes|string|max:255',
             'email' => 'sometimes|email|unique:users,email,' . $id,
             'password' => 'sometimes|string|min:8|confirmed',
-            'role' => 'sometimes|in:admin',
+            'role' => 'sometimes|in:admin,editor',
         ]);
 
         $user->update([
@@ -117,7 +117,7 @@ class SuperAdminController extends Controller
         }
 
         $request->validate([
-            'role' => 'required|in:admin,super_admin,editor',
+            'role' => 'required|in:admin,editor',
         ]);
 
         $user->role = $request->role;

--- a/database/migrations/2025_03_26_150430_create_editors_table.php
+++ b/database/migrations/2025_03_26_150430_create_editors_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('editors', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('user_id')->constrained('users');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
             $table->foreignId('conference_id')->constrained('conferences')->onDelete('cascade');
             $table->foreignId('assigned_by')->constrained('users');
             $table->timestamps();


### PR DESCRIPTION
Replaces 'super_admin' with 'editor' in role validation to align with updated role requirements across multiple methods.

Adds cascading delete constraint to the 'user_id' column in the 'editors' table to ensure proper cleanup of related records when a user is deleted.